### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ MCP Server for running code snippet and show the result.
 
 It supports running multiple programming languages: **JavaScript, PHP, Python, Perl, Perl 6, Ruby, Go, Lua, Groovy, PowerShell, BAT/CMD, BASH/SH, F# Script, C# Script, VBScript, TypeScript, CoffeeScript, Scala, Swift, Julia, Crystal, OCaml Script, R, AppleScript, Elixir, Clojure, Racket, Scheme, AutoHotkey, AutoIt, Kotlin Script, Dart, Haskell, Ni, Lisp, Kit, V, SCSS, Sass**. Full list could be seen here in [constants.ts](https://github.com/formulahendry/mcp-server-code-runner/blob/main/src/constants.ts).
 
+<a href="https://glama.ai/mcp/servers/d3mluq4vy9">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/d3mluq4vy9/badge" alt="mcp-server-code-runner MCP server" />
+</a>
+
 ## Setup
 
 ### VS Code


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-code-runner](https://glama.ai/mcp/servers/d3mluq4vy9) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/d3mluq4vy9">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/d3mluq4vy9/badge" alt="mcp-server-code-runner MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.