### PR TITLE
Make mcp server awaitable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,8 @@ import { createServer } from "./server.js";
 async function main() {
     const server: McpServer = createServer();
     const transport = new StdioServerTransport();
-    await server.connect(transport);
     console.debug("Code Runner MCP Server running on stdio");
+    return await server.connect(transport);
 }
 
 main().catch((error) => {


### PR DESCRIPTION
This change fixes the problem of connecting to the server through mcp-proxy:

```
mcp-proxy --sse-port=9991 --pass-environment -- bunx mcp-server-code-runner@latest
```